### PR TITLE
Switch from DeepSpeech to Coqui STT

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -76,6 +76,11 @@ Its structure is the following one:
 .. code-block:: json
 
     {
+      "coqui": {
+        "model" :"coqui-1.0.tflite",
+        "scorer" :"huge-vocabulary.scorer",
+        "beam_width": 500
+      },
       "deepspeech": {
         "model" :"deepspeech-0.7.1-models.pbmm",
         "scorer" :"deepspeech-0.7.1-models.scorer",
@@ -98,6 +103,17 @@ Its structure is the following one:
     }
 
 The configuration file contains several sections and sub-sections.
+
+coqui section configuration
+---------------------------
+
+Section "coqui" contains configuration of the coqui-stt engine:
+
+**model**: The model that was trained by coqui. Must be a tflite (TensorFlow Lite) file.
+
+**scorer**: [Optional] The scorer file. Use this to tune the STT to understand certain phrases better
+
+**beam_width**: [Optional] The size of the beam search. Corresponds directly to how long decoding takes
 
 deepspeech section configuration
 --------------------------------

--- a/README.rst
+++ b/README.rst
@@ -11,16 +11,22 @@ DeepSpeech Server
 Key Features
 ============
 
-This is an http server that can be used to test the Mozilla DeepSpeech project.
-You need an environment with DeepSpeech and a model to run this server.
+This is an http server that can be used to test the Mozilla DeepSpeech project
+or its successor, the Coqui STT project. You need an environment with
+DeepSpeech or Coqui to run this server.
 
-This code uses the DeepSpeech 0.7 APIs.
+This code uses the DeepSpeech 0.7 APIs and Coqui STT 1.0 APIs.
 
 Installation
 =============
 
-You first need to install deepspeech. Depending on your system you can use the
-CPU package:
+Before starting, you'll need to choose an engine.
+
+Option A: Installing DeepSpeech
+-------------------------------
+
+First, install `deepspeech`. Depending on your system you can use the CPU
+package:
 
 .. code-block:: console
 
@@ -31,6 +37,19 @@ Or the GPU package:
 .. code-block:: console
 
     pip3 install deepspeech-gpu
+
+Option B: Installing Coqui STT
+------------------------------
+
+First, install `stt` (published by Coqui). There is only one package available,
+but not to worry - it supports both CPU-bound and GPU environments:
+
+.. code-block:: console
+
+   pip3 install stt
+
+Installing deepspeech-server
+----------------------------
 
 Then you can install the deepspeech server:
 
@@ -53,18 +72,62 @@ Starting the server
 
     deepspeech-server --config config.json
 
+What is a STT model?
+--------------------
+
+The quality of the speech-to-text engine depends heavily on which models it
+loads at runtime. Think of them as a sort of pattern that controls how the
+engine works.
+
+Coqui and deepspeech models both run on tensorflow, but the way they are built
+means that the models for one cannot be used for the other. Note that the files
+used for vocabulary (the so-called scorers) ARE compatible. Refer to the below
+table:
+
+.. csv-table:: Supported Formats
+   :header: "Name", "Extension", "Engine Support"
+
+   "Protobuf", "`.pb`", "Deepspeech"
+   "Memory-mapped Protobuf", "`.pbmm`", "DeepSpeech"
+   "TensorFlow Lite", "`.tflite`", "DeepSpeech, Coqui STT"
+   "Scorer", "`.scorer`", "DeepSpeech, Coqui STT"
+
+How to use a specific STT model
+-------------------------------
+
 You can use deepspeech without training a model yourself. Pre-trained
 models are provided by Mozilla in the release page of the project (See the
 assets section of the release note):
 
 https://github.com/mozilla/DeepSpeech/releases
 
-Once your downloaded a pre-trained model, you can untar it and directly use the
-sample configuration file:
+You can also use coqui without training a model. Pre-trained models are on
+offer at the Coqui Model Zoo (Make sure the STT Models tab is selected):
+
+https://coqui.ai/models
+
+Once you've downloaded a pre-trained model, make a copy of the sample
+configuration file. Edit the `"model"` and `"scorer"` fields in your new file
+for the engine you want to use so that they match the downloaded files:
 
 .. code-block:: console
 
     cp config.sample.json config.json
+    $EDITOR config.json
+
+Here's what to change if you want to use the models from deepspeech 0.9.3:
+
+.. code-block:: json
+
+     "deepspeech": {
+       "model" :"/path/to/my/downloaded/models/deepspeech-0.9.3-models.pbmm",
+       "scorer" :"/path/to/my/downloaded/models/deepspeech-0.9.3-models.scorer"
+     },
+
+Lastly, start the server in the usual way:
+
+.. code-block:: console
+
     deepspeech-server --config config.json
 
 Server configuration

--- a/config.sample.json
+++ b/config.sample.json
@@ -1,4 +1,9 @@
 {
+  "coqui": {
+    "model" :"coqui-1.0.tflite",
+    "scorer" :"huge-vocabulary.scorer",
+    "beam_width": 500
+  },
   "deepspeech": {
     "model" :"deepspeech-0.7.1-models.pbmm",
     "scorer" :"deepspeech-0.7.1-models.scorer"

--- a/deepspeech_server/coqui.py
+++ b/deepspeech_server/coqui.py
@@ -1,0 +1,100 @@
+import io
+import logging
+from collections import namedtuple
+
+import rx
+from cyclotron import Component
+from cyclotron_std.logging import Log
+from deepspeech import Model
+
+import deepspeech_server.decoding as decoding
+
+
+Sink = namedtuple('Sink', ['speech'])
+Source = namedtuple('Source', ['text', 'log'])
+
+# Sink events
+Scorer = namedtuple('Scorer', ['scorer', 'lm_alpha', 'lm_beta'])
+Scorer.__new__.__defaults__ = (None, None, None)
+
+Initialize = namedtuple('Initialize', ['model', 'scorer', 'beam_width'])
+Initialize.__new__.__defaults__ = (None,)
+
+SpeechToText = namedtuple('SpeechToText', ['data', 'context'])
+
+# Sourc eevents
+TextResult = namedtuple('TextResult', ['text', 'context'])
+TextError = namedtuple('TextError', ['error', 'context'])
+
+
+def make_driver(loop=None):
+    def driver(sink):
+        model = None
+        log_observer = None
+
+        def on_log_subscribe(observer, scheduler):
+            nonlocal log_observer
+            log_observer = observer
+
+        def log(message, level=logging.DEBUG):
+            if log_observer is not None:
+                log_observer.on_next(Log(
+                    logger=__name__,
+                    level=level,
+                    message=message,
+                ))
+
+        def setup_model(model_path, scorer, beam_width):
+            log("creating model {} with scorer {}...".format(model_path, scorer))
+            model = Model(model_path)
+
+            if scorer.scorer is not None:
+                model.enableExternalScorer(scorer.scorer)
+                if scorer.lm_alpha is not None and scorer.lm_beta is not None:
+                    if model.setScorerAlphaBeta(scorer.lm_alpha, scorer.lm_beta) != 0:
+                        raise RuntimeError("Unable to set scorer parameters")
+
+            if beam_width is not None:
+                if model.setBeamWidth(beam_width) != 0:
+                    raise RuntimeError("Unable to set beam width")
+
+            log("model is ready.")
+            return model
+
+        def subscribe(observer, scheduler):
+            def on_deepspeech_request(item):
+                nonlocal model
+
+                if type(item) is SpeechToText:
+                    if model is not None:
+                        try:
+                            audio = decoding.decode_audio(io.BytesIO(item.data))
+                            text = model.stt(audio)
+                            log("STT result: {}".format(text))
+                            observer.on_next(rx.just(TextResult(
+                                text=text,
+                                context=item.context,
+                            )))
+                        except Exception as e:
+                            log("STT error: {}".format(e), level=logging.ERROR)
+                            observer.on_next(rx.throw(TextError(
+                                error=e,
+                                context=item.context,
+                            )))
+                elif type(item) is Initialize:
+                    log("initialize: {}".format(item))
+                    model = setup_model(
+                        item.model, item.scorer, item.beam_width)
+                else:
+                    log("unknown item: {}".format(item), level=logging.CRITICAL)
+                    observer.on_error(
+                        "Unknown item type: {}".format(type(item)))
+
+            sink.speech.subscribe(lambda item: on_deepspeech_request(item))
+
+        return Source(
+            text=rx.create(subscribe),
+            log=rx.create(on_log_subscribe),
+        )
+
+    return Component(call=driver, input=Sink)

--- a/deepspeech_server/coqui.py
+++ b/deepspeech_server/coqui.py
@@ -5,7 +5,7 @@ from collections import namedtuple
 import rx
 from cyclotron import Component
 from cyclotron_std.logging import Log
-from deepspeech import Model
+from stt import Model
 
 import deepspeech_server.decoding as decoding
 
@@ -62,7 +62,7 @@ def make_driver(loop=None):
             return model
 
         def subscribe(observer, scheduler):
-            def on_deepspeech_request(item):
+            def on_coqui_request(item):
                 nonlocal model
 
                 if type(item) is SpeechToText:
@@ -90,7 +90,7 @@ def make_driver(loop=None):
                     observer.on_error(
                         "Unknown item type: {}".format(type(item)))
 
-            sink.speech.subscribe(lambda item: on_deepspeech_request(item))
+            sink.speech.subscribe(lambda item: on_coqui_request(item))
 
         return Source(
             text=rx.create(subscribe),

--- a/deepspeech_server/decoding.py
+++ b/deepspeech_server/decoding.py
@@ -26,7 +26,13 @@ def decode_audio_pyav(file):
     )
     resampled_frames = []
     for frame in audio.decode(audio=0):
-        resampled_frames.append(resampler.resample(frame).to_ndarray().flatten())
+        # As of PyAV 9.0, one input frame may be resampled to multiple outputs.
+        # Convert each into a numpy ndarray...
+        iterable_frames = map(lambda f:f.to_ndarray(), resampler.resample(frame))
+        # ...then flatten each of those arrays down to 1D
+        flat_frames = list(map(lambda f:f.flatten(), iterable_frames))
+        # Add all of the resampled frames to our output list
+        resampled_frames.extend(flat_frames)
 
     return np.concatenate(resampled_frames)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ scipy>=1.0
 cyclotron>=1.2
 cyclotron-aiohttp>=1.0
 cyclotron-std>=1.0
-av==8.0.2
+av==9.2.0
 numpy

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ install_requires = [
 
 setup(
     name="deepspeech-server",
-    version='2.2.0',
+    version='2.3.0-dev',
     url='https://github.com/MainRo/deepspeech-server.git',
     license='MPL-2.0',
     description="server for mozilla deepspeech",


### PR DESCRIPTION
# Overview

Fixes #41.

We now require [Coqui STT](https://github.com/coqui-ai/STT) in the host environment. I've added new details to the README to explain how to configure your installation to work with that engine.

# Other notes

This also upgrades PyAV to 9.2.0.

While these changes do not delete `deepspeech.py`, there is currently no way to build the server with simultaneous support for both DeepSpeech and Coqui STT. If we want to support both, we will need to make improvements to `server.py`.